### PR TITLE
Fix CMake conditional to allow FreeBSD build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -335,7 +335,7 @@ if(APPLE)
     set(MACOSX_BUNDLE_BUNDLE_VERSION "1.0.0")
 endif()
 
-if(NOT ${CMAKE_SYSTEM_NAME} MATCHES "Linux")
+if((NOT ${CMAKE_SYSTEM_NAME} MATCHES "Linux") AND (NOT ${CMAKE_SYSTEM_NAME} MATCHES "FreeBSD"))
     add_subdirectory("third_party/sdl2")
 else()
     find_package(SDL2)


### PR DESCRIPTION
This builds and runs under FreeBSD if the internal SDL2 isn't used.