### PR TITLE
Add support for SCALE_2X to f1_res.ini

### DIFF
--- a/src/plib/gnw/svga.cc
+++ b/src/plib/gnw/svga.cc
@@ -126,6 +126,13 @@ static int GNW95_init_mode_ex(int width, int height, int bpp)
             int scaleValue;
             if (config_get_value(&resolutionConfig, "MAIN", "SCALE_2X", &scaleValue)) {
                 scale = scaleValue + 1; // 0 = 1x, 1 = 2x
+                // Only allow scaling if resulting game resolution is >= 640x480
+                if ((width / scale) < 640 || (height / scale) < 480) {
+                    scale = 1;
+                } else {
+                    width /= scale;
+                    height /= scale;
+                }
             }
         }
         config_exit(&resolutionConfig);

--- a/src/plib/gnw/svga.cc
+++ b/src/plib/gnw/svga.cc
@@ -103,6 +103,7 @@ void reset_mode()
 static int GNW95_init_mode_ex(int width, int height, int bpp)
 {
     bool fullscreen = true;
+    int scale = 1;
 
     Config resolutionConfig;
     if (config_init(&resolutionConfig)) {
@@ -121,11 +122,16 @@ static int GNW95_init_mode_ex(int width, int height, int bpp)
             if (configGetBool(&resolutionConfig, "MAIN", "WINDOWED", &windowed)) {
                 fullscreen = !windowed;
             }
+
+            int scaleValue;
+            if (config_get_value(&resolutionConfig, "MAIN", "SCALE_2X", &scaleValue)) {
+                scale = scaleValue + 1; // 0 = 1x, 1 = 2x
+            }
         }
         config_exit(&resolutionConfig);
     }
 
-    if (GNW95_init_window(width, height, fullscreen) == -1) {
+    if (GNW95_init_window(width, height, fullscreen, scale) == -1) {
         return -1;
     }
 
@@ -152,7 +158,7 @@ static int GNW95_init_mode(int width, int height)
 }
 
 // 0x4CAEDC
-int GNW95_init_window(int width, int height, bool fullscreen)
+int GNW95_init_window(int width, int height, bool fullscreen, int scale)
 {
     if (gSdlWindow == NULL) {
         SDL_SetHint(SDL_HINT_RENDER_DRIVER, "opengl");
@@ -167,7 +173,7 @@ int GNW95_init_window(int width, int height, bool fullscreen)
             windowFlags |= SDL_WINDOW_FULLSCREEN;
         }
 
-        gSdlWindow = SDL_CreateWindow(GNW95_title, SDL_WINDOWPOS_UNDEFINED, SDL_WINDOWPOS_UNDEFINED, width, height, windowFlags);
+        gSdlWindow = SDL_CreateWindow(GNW95_title, SDL_WINDOWPOS_UNDEFINED, SDL_WINDOWPOS_UNDEFINED, width * scale, height * scale, windowFlags);
         if (gSdlWindow == NULL) {
             return -1;
         }

--- a/src/plib/gnw/svga.h
+++ b/src/plib/gnw/svga.h
@@ -30,7 +30,7 @@ int init_mode_1280_1024();
 int init_vesa_mode(int mode, int width, int height, int half);
 int get_start_mode();
 void reset_mode();
-int GNW95_init_window(int width, int height, bool fullscreen);
+int GNW95_init_window(int width, int height, bool fullscreen, int scale);
 int GNW95_init_DirectDraw(int width, int height, int bpp);
 void GNW95_reset_mode();
 void GNW95_SetPaletteEntries(unsigned char* a1, int a2, int a3);


### PR DESCRIPTION
This PR adds support for the Fallout high-resolution pack's`SCALE_2X` option in `f1_res.ini`, which pixel-doubles the game window's contents for crisp graphics on higher-resolution monitors. Makes a big difference in playability on my 1080p laptop, which doesn't properly support 960x540 resolution in Linux (gets forced into a squished, letterboxed 800x600) but looks great with 2x scaling. Also looks great on my old pre-Retina iMac, running at 1280x720 pixel-doubled to 1440p.

![Screen Shot 2023-06-02 at 10 44 27 PM](https://github.com/alexbatalov/fallout1-ce/assets/18648066/07ed3b2e-e6dc-48fb-b108-6705181e1859)
![Screen Shot 2023-06-02 at 10 44 55 PM](https://github.com/alexbatalov/fallout1-ce/assets/18648066/c133d07f-4bb5-447b-a4a0-df5eec214a2d)

This should also allow for 3x or 4x scaling as well on HiDPI monitors, by setting `SCALE_2X` to 2 or 3, respectively.

I've tried to match the surrounding code style as best I can, but let me know if there's anything I can tweak!
