### PR TITLE
Fix broken game load/save on Linux due to case sensitive opendir()

### DIFF
--- a/src/plib/db/db.cc
+++ b/src/plib/db/db.cc
@@ -2575,6 +2575,7 @@ static int db_findfirst(const char* path, DB_FIND_DATA* findData)
     char basePath[COMPAT_MAX_PATH];
     compat_makepath(basePath, drive, dir, NULL, NULL);
 
+    compat_resolve_path(basePath);
     findData->dir = opendir(basePath);
     if (findData->dir == NULL) {
         return -1;


### PR DESCRIPTION
I compiled fallout-ce on my RaspberryPi-400 and uConsole (a similar device). Everything seems to be working fine except game saving and loading were not working, and would pop up a dialog saying saving/loading failed.

I traced this back to a failure of the `opendir()` call in `src/plib/db/db.cc`.   Part of the path it is trying to open is formed from the so-called `patches_path`.

This seems to come from the `critter_patches=data` and `master_patches=data` entries in the fallout.cfg config.
If there is no fallout.cfg file then the defaults used by fallout can be found at `src/game/gconfig.cc:59`:
```c
    // Initialize defaults.
   . ..
    config_set_string(&game_config, GAME_CONFIG_SYSTEM_KEY, GAME_CONFIG_MASTER_PATCHES_KEY, "data");
    ...
    config_set_string(&game_config, GAME_CONFIG_SYSTEM_KEY, GAME_CONFIG_CRITTER_PATCHES_KEY, "data");
```

The game files that I have from Steam however use an upper case naming scheme for the `DATA` folder.  
The `opendir` call was then failing because using lower case `data` in the path would not match the upper case `DATA` of my files.

I found the `compat_resolve_path` function, which looks like it accounts for this and will adjust a path to match the case used by the file system. Using this function before `opendir()` resolved the problem for me and I can now load and save the game correctly on my RaspberryPi running Linux using the Steam data files.

Is an upper case `DATA` folder conventional on all distributions of fallout?
I wonder if we should adjust the default values to be upper case to be a little more correct if that is true?

If someone suggests a more appropriate place to do the path conversion, I'd be happy to revise this patch.

Also this may relate to #102 