### PR TITLE
use uppercase music file in main menu

### DIFF
--- a/src/game/main.cc
+++ b/src/game/main.cc
@@ -107,7 +107,7 @@ int gnw_main(int argc, char** argv)
 
         while (!done) {
             kb_clear();
-            gsound_background_play_level_music("07desert", 11);
+            gsound_background_play_level_music("07DESERT", 11);
             main_menu_show(1);
 
             mouse_show();


### PR DESCRIPTION
As per the docs:

> Music files themselves (with ACM extension) should be all uppercased, regardless of sound and music folders.

Running under strace shows ENOENT due to hardcoded lower-case

```
strace -e trace=open,openat fallout-ce

openat(AT_FDCWD, "data/sound/music/07desert.ACM", O_RDONLY) = -1 ENOENT (No such file or directory)
```