### PR TITLE
Divide mouse sensitivity by window scale

### DIFF
--- a/src/plib/gnw/gnw.cc
+++ b/src/plib/gnw/gnw.cc
@@ -157,6 +157,7 @@ int win_init(VideoOptions* video_options, int flags)
     if (GNW_input_init(flags) == -1) {
         return WINDOW_MANAGER_ERR_INITIALIZING_INPUT;
     }
+    mouseSetWindowScale(video_options->scale);
 
     GNW_intr_init();
 

--- a/src/plib/gnw/mouse.cc
+++ b/src/plib/gnw/mouse.cc
@@ -123,6 +123,8 @@ static char mouse_trans;
 static int gMouseWheelX = 0;
 static int gMouseWheelY = 0;
 
+static int gWindowScale = 1;
+
 // 0x4B4780
 int GNW_mouse_init()
 {
@@ -798,7 +800,7 @@ bool mouse_is_disabled()
 void mouse_set_sensitivity(double value)
 {
     if (value > 0 && value < 2.0) {
-        mouse_sensitivity = value;
+        mouse_sensitivity = value / gWindowScale;
     }
 }
 
@@ -873,6 +875,11 @@ void convertMouseWheelToArrowKey(int* keyCodePtr)
             }
         }
     }
+}
+
+void mouseSetWindowScale(int scale)
+{
+    gWindowScale = scale;
 }
 
 } // namespace fallout

--- a/src/plib/gnw/mouse.h
+++ b/src/plib/gnw/mouse.h
@@ -64,6 +64,7 @@ void mouseGetPositionInWindow(int win, int* x, int* y);
 bool mouseHitTestInWindow(int win, int left, int top, int right, int bottom);
 void mouseGetWheel(int* x, int* y);
 void convertMouseWheelToArrowKey(int* keyCodePtr);
+void mouseSetWindowScale(int scale);
 
 } // namespace fallout
 


### PR DESCRIPTION
Mouse sensitivity is too high when using `SCALE_2X`. I'm not super familiar with the codebase but this seems like a reasonable way to keep sensitivity the same across different scales.