### PR TITLE
support for non-exclusive fullscreen mode aka windowed borderless

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -391,3 +391,4 @@ FodyWeavers.xsd
 # CMake
 /out
 /build
+.DS_Store

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,16 +1,18 @@
-cmake_minimum_required(VERSION 3.13)
+cmake_minimum_required(VERSION 3.5)
 
+set(CMAKE_POLICY_VERSION_MINIMUM 3.5)
 set(CMAKE_POLICY_DEFAULT_CMP0077 NEW)
 
 set(EXECUTABLE_NAME fallout-ce)
+set(CMAKE_OSX_SYSROOT "/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk")
 
 if (APPLE)
     if(IOS)
-        set(CMAKE_OSX_DEPLOYMENT_TARGET "11" CACHE STRING "")
+        set(CMAKE_OSX_DEPLOYMENT_TARGET "12" CACHE STRING "")
         set(CMAKE_OSX_ARCHITECTURES "arm64" CACHE STRING "")
     else()
-        set(CMAKE_OSX_DEPLOYMENT_TARGET "10.11" CACHE STRING "")
-        set(CMAKE_OSX_ARCHITECTURES "x86_64;arm64" CACHE STRING "")
+        set(CMAKE_OSX_DEPLOYMENT_TARGET "10.13" CACHE STRING "")
+        set(CMAKE_OSX_ARCHITECTURES "arm64" CACHE STRING "")
     endif()
 endif()
 

--- a/src/game/game.cc
+++ b/src/game/game.cc
@@ -148,6 +148,7 @@ int game_init(const char* windowTitle, bool isMapper, int font, int flags, int a
     video_options.height = 480;
     video_options.fullscreen = true;
     video_options.scale = 1;
+    video_options.exclusive = 1;
 
     Config resolutionConfig;
     if (config_init(&resolutionConfig)) {
@@ -165,6 +166,11 @@ int game_init(const char* windowTitle, bool isMapper, int font, int flags, int a
             bool windowed;
             if (configGetBool(&resolutionConfig, "MAIN", "WINDOWED", &windowed)) {
                 video_options.fullscreen = !windowed;
+            }
+
+            bool exclusive;
+            if (configGetBool(&resolutionConfig, "MAIN", "EXCLUSIVE", &exclusive)) {
+                video_options.exclusive = exclusive;
             }
 
             int scaleValue;

--- a/src/movie_lib.cc
+++ b/src/movie_lib.cc
@@ -99,7 +99,7 @@ static void _nfPkDecomp(unsigned char* buf, unsigned char* a2, int a3, int a4, i
 
 static constexpr uint16_t loadUInt16LE(const uint8_t* b);
 static constexpr uint32_t loadUInt32LE(const uint8_t* b);
-static uint8_t getOffset(uint16_t v);
+static int16_t getOffset(uint16_t v);
 
 // 0x51EBD8
 static int dword_51EBD8 = 0;
@@ -2802,7 +2802,7 @@ constexpr uint32_t loadUInt32LE(const uint8_t* b)
     return (b[3] << 24) | (b[2] << 16) | (b[1] << 8) | b[0];
 }
 
-uint8_t getOffset(uint16_t v)
+int16_t getOffset(uint16_t v)
 {
     return static_cast<int8_t>(v & 0xFF) + dword_51F018[v >> 8];
 }

--- a/src/plib/gnw/svga.cc
+++ b/src/plib/gnw/svga.cc
@@ -91,7 +91,10 @@ bool svga_init(VideoOptions* video_options)
     Uint32 windowFlags = SDL_WINDOW_OPENGL | SDL_WINDOW_ALLOW_HIGHDPI;
 
     if (video_options->fullscreen) {
-        windowFlags |= SDL_WINDOW_FULLSCREEN;
+        if (video_options->exclusive)
+            windowFlags |= SDL_WINDOW_FULLSCREEN;
+        else
+            windowFlags |= SDL_WINDOW_FULLSCREEN_DESKTOP;
     }
 
     gSdlWindow = SDL_CreateWindow(GNW95_title, SDL_WINDOWPOS_UNDEFINED, SDL_WINDOWPOS_UNDEFINED,

--- a/src/plib/gnw/svga_types.h
+++ b/src/plib/gnw/svga_types.h
@@ -19,6 +19,7 @@ typedef struct VideoOptions {
     int height;
     bool fullscreen;
     int scale;
+    bool exclusive;
 } VideoOptions;
 
 } // namespace fallout


### PR DESCRIPTION
Another parameter to f1_res.ini
EXCLUSIVE=0 (1 by default)
this mode it perfect for MacOS users allowing to switch between apps.