### PR TITLE
Disable SDL2 conversion of touch->mouse and mouse->touch on all platforms not just iOS/Android

### DIFF
--- a/src/plib/gnw/winmain.cc
+++ b/src/plib/gnw/winmain.cc
@@ -33,6 +33,9 @@ int main(int argc, char* argv[])
 {
     int rc;
 
+    SDL_SetHint(SDL_HINT_MOUSE_TOUCH_EVENTS, "0");
+    SDL_SetHint(SDL_HINT_TOUCH_MOUSE_EVENTS, "0");
+
 #if _WIN32
     GNW95_mutex = CreateMutexA(0, TRUE, "GNW95MUTEX");
     if (GetLastError() != ERROR_SUCCESS) {
@@ -41,8 +44,6 @@ int main(int argc, char* argv[])
 #endif
 
 #if __APPLE__ && TARGET_OS_IOS
-    SDL_SetHint(SDL_HINT_MOUSE_TOUCH_EVENTS, "0");
-    SDL_SetHint(SDL_HINT_TOUCH_MOUSE_EVENTS, "0");
     chdir(iOSGetDocumentsPath());
 #endif
 
@@ -53,8 +54,6 @@ int main(int argc, char* argv[])
 #endif
 
 #if __ANDROID__
-    SDL_SetHint(SDL_HINT_MOUSE_TOUCH_EVENTS, "0");
-    SDL_SetHint(SDL_HINT_TOUCH_MOUSE_EVENTS, "0");
     chdir(SDL_AndroidGetExternalStoragePath());
 #endif
 


### PR DESCRIPTION
By default, SDL2 simulates mouse events from real touch input, and simulates touch events from real mouse input. This project doesn't require either of those, because it handles both touch and mouse inputs itself.

The existing code specifically disables both these simulation features when the platform is iOS, and also when the platform is Android. This likely covers most touchscreen gadgets being used, but when run on a different platform with a touchscreen (in my case, a Nintendo Switch running Linux), the touchscreen events are duplicated as simulated mouse events, leading to the mouse cursor jumping after a movement is finished, as I created an [issue](https://github.com/alexbatalov/fallout1-ce/issues/172) about.

I'm happy to be corrected if I'm wrong, but I can't see any downside to disabling these SDL2 features for all platforms, simulation of touch or mouse never being required because the game handles both. Let me know if anything needs improving, ty.