### PR TITLE
Patched snprintf() calls to provide required format specifiers

### DIFF
--- a/src/game/protinst.cc
+++ b/src/game/protinst.cc
@@ -965,7 +965,7 @@ static int protinst_default_use_item(Object* a1, Object* a2, Object* item)
 
     messageListItem.num = 582;
     if (message_search(&proto_main_msg_file, &messageListItem)) {
-        snprintf(formattedText, sizeof(formattedText), messageListItem.text);
+        snprintf(formattedText, sizeof(formattedText), "%s", messageListItem.text);
         display_print(formattedText);
     }
     return -1;

--- a/src/int/audio.cc
+++ b/src/int/audio.cc
@@ -60,7 +60,7 @@ static int decodeRead(void* stream, void* buffer, unsigned int size)
 int audioOpen(const char* fname, int flags)
 {
     char path[80];
-    snprintf(path, sizeof(path), fname);
+    snprintf(path, sizeof(path), "%s", fname);
 
     int compression;
     if (queryCompressedFunc(path)) {


### PR DESCRIPTION
Unable to compile on linux due to missing format specifiers per the CPP reference. 
https://cplusplus.com/reference/cstdio/snprintf

PR patches snprintf() calls to provide the required format specifiers. 