### PR TITLE
movie_lib.cc: Fix incorrect return type of `getOffset`

### DIFF
--- a/src/movie_lib.cc
+++ b/src/movie_lib.cc
@@ -99,7 +99,7 @@ static void _nfPkDecomp(unsigned char* buf, unsigned char* a2, int a3, int a4, i
 
 static constexpr uint16_t loadUInt16LE(const uint8_t* b);
 static constexpr uint32_t loadUInt32LE(const uint8_t* b);
-static uint8_t getOffset(uint16_t v);
+static int getOffset(uint16_t v);
 
 // 0x51EBD8
 static int dword_51EBD8 = 0;
@@ -2802,7 +2802,7 @@ constexpr uint32_t loadUInt32LE(const uint8_t* b)
     return (b[3] << 24) | (b[2] << 16) | (b[1] << 8) | b[0];
 }
 
-uint8_t getOffset(uint16_t v)
+int getOffset(uint16_t v)
 {
     return static_cast<int8_t>(v & 0xFF) + dword_51F018[v >> 8];
 }


### PR DESCRIPTION
The type was changed from `auto` to `uint8_t` when merging #117, but the correct return type is actually `int`.

Fixes #136
Fixes #194 

There is an alternative fix in #188 (with a graph of generated values) but I think the return type there (`int16_t`) is incorrect.

/cc @alexbatalov @Zenkibou @hippydave @KulikAlex @dje4321