### PR TITLE
chores: gitignore CMake

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -391,3 +391,10 @@ FodyWeavers.xsd
 # CMake
 /out
 /build
+/_deps
+/CMakeFiles
+/third_party
+/Makefile
+/cmake_install.cmake
+/CMakeCache.txt
+/fallout-ce


### PR DESCRIPTION
Adds some other files and directories that CMake creates when building the project on linux.

### Cmake version
3.28.1