### PR TITLE
Fix format-security build error

### DIFF
--- a/src/game/protinst.cc
+++ b/src/game/protinst.cc
@@ -965,8 +965,7 @@ static int protinst_default_use_item(Object* a1, Object* a2, Object* item)
 
     messageListItem.num = 582;
     if (message_search(&proto_main_msg_file, &messageListItem)) {
-        snprintf(formattedText, sizeof(formattedText), messageListItem.text);
-        display_print(formattedText);
+        display_print(messageListItem.text);
     }
     return -1;
 }

--- a/src/int/audio.cc
+++ b/src/int/audio.cc
@@ -60,7 +60,7 @@ static int decodeRead(void* stream, void* buffer, unsigned int size)
 int audioOpen(const char* fname, int flags)
 {
     char path[80];
-    snprintf(path, sizeof(path), fname);
+    strncpy(path, fname, sizeof(path));
 
     int compression;
     if (queryCompressedFunc(path)) {


### PR DESCRIPTION
error: format not a string literal and no format arguments [-Werror=format-security]