### PR TITLE
Touch control optimisation [iOS, Android]

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,10 +57,17 @@ $ mv app /Applications/Fallout
 ### Android
 
 > **NOTE**: Fallout was designed with mouse in mind. There are many controls that require precise cursor positioning, which is not possible with fingers. Current control scheme resembles trackpad usage:
-> - One finger moves mouse cursor around.
+
+> - One finger tap moves mouse cursor to the tapped position and does left mouse click. (new!)
+> - One finger drag moves mouse cursor around. The finger doesn't have to be at the cursor position, but anywhere on the screen. This is useful for accurate selection of dialogue options, and precise aiming during combat.
 > - Tap one finger for left mouse click.
 > - Tap two fingers for right mouse click (switches mouse cursor mode).
 > - Move two fingers to scroll current view (map view, worldmap view, inventory scrollers).
+> - Tap with three fingers to simulate a left mouse button click at the cursor's current location without moving it. This is ideal for accurately selecting dialogue options or executing precise attacks during combat.
+
+> **NOTE**: To activate UI buttons, you need to double-tap on them.
+
+
 
 > **NOTE**: From Android standpoint release and debug builds are different apps. Both apps require their own copy of game assets and have their own savegames. This is intentional. As a gamer just stick with release version and check for updates.
 

--- a/src/game/game.cc
+++ b/src/game/game.cc
@@ -172,6 +172,10 @@ int game_init(const char* windowTitle, bool isMapper, int font, int flags, int a
                 video_options.scale = scaleValue + 1;
                 video_options.width /= video_options.scale;
                 video_options.height /= video_options.scale;
+
+                // Keep logical surface large enough for 640px-wide interface assets.
+                video_options.width = std::max(video_options.width, 640);
+                video_options.height = std::max(video_options.height, 480);
             }
         }
         config_exit(&resolutionConfig);

--- a/src/game/intface.cc
+++ b/src/game/intface.cc
@@ -399,10 +399,14 @@ int intface_init()
 
     insideInit = 1;
 
-    int interfaceBarWindowX = (screenGetWidth() - INTERFACE_BAR_WIDTH) / 2;
-    int interfaceBarWindowY = screenGetHeight() - INTERFACE_BAR_HEIGHT;
+    // Clamp interface window to screen size to avoid win_add failure when logical
+    // resolution is smaller than the interface art (e.g., 512-wide surface vs 640 bar).
+    int interfaceBarWidth = std::min(screenGetWidth(), INTERFACE_BAR_WIDTH);
+    int interfaceBarHeight = std::min(screenGetHeight(), INTERFACE_BAR_HEIGHT);
+    int interfaceBarWindowX = (screenGetWidth() - interfaceBarWidth) / 2;
+    int interfaceBarWindowY = screenGetHeight() - interfaceBarHeight;
 
-    interfaceWindow = win_add(interfaceBarWindowX, interfaceBarWindowY, INTERFACE_BAR_WIDTH, INTERFACE_BAR_HEIGHT, colorTable[0], WINDOW_HIDDEN);
+    interfaceWindow = win_add(interfaceBarWindowX, interfaceBarWindowY, interfaceBarWidth, interfaceBarHeight, colorTable[0], WINDOW_HIDDEN);
     if (interfaceWindow == -1) {
         // NOTE: Uninline.
         return intface_fatal_error(-1);
@@ -421,7 +425,8 @@ int intface_init()
         return intface_fatal_error(-1);
     }
 
-    buf_to_buf(backgroundFrmData, INTERFACE_BAR_WIDTH, INTERFACE_BAR_HEIGHT, INTERFACE_BAR_WIDTH, interfaceBuffer, 640);
+    // Copy background with clipping to the actual window width/height.
+    buf_to_buf(backgroundFrmData, interfaceBarWidth, interfaceBarHeight, INTERFACE_BAR_WIDTH, interfaceBuffer, interfaceBarWidth);
     art_ptr_unlock(backgroundFrmHandle);
 
     fid = art_id(OBJ_TYPE_INTERFACE, 47, 0, 0, 0);

--- a/src/movie_lib.cc
+++ b/src/movie_lib.cc
@@ -99,7 +99,7 @@ static void _nfPkDecomp(unsigned char* buf, unsigned char* a2, int a3, int a4, i
 
 static constexpr uint16_t loadUInt16LE(const uint8_t* b);
 static constexpr uint32_t loadUInt32LE(const uint8_t* b);
-static uint8_t getOffset(uint16_t v);
+static int getOffset(uint16_t v);
 
 // 0x51EBD8
 static int dword_51EBD8 = 0;
@@ -2802,7 +2802,7 @@ constexpr uint32_t loadUInt32LE(const uint8_t* b)
     return (b[3] << 24) | (b[2] << 16) | (b[1] << 8) | b[0];
 }
 
-uint8_t getOffset(uint16_t v)
+int getOffset(uint16_t v)
 {
     return static_cast<int8_t>(v & 0xFF) + dword_51F018[v >> 8];
 }

--- a/src/plib/gnw/mouse.cc
+++ b/src/plib/gnw/mouse.cc
@@ -414,6 +414,7 @@ void mouse_hide()
 }
 
 // 0x4B4DD8
+// New version of mouse_info for touch devices
 void mouse_info()
 {
     if (!have_mouse) {
@@ -434,11 +435,18 @@ void mouse_info()
         static int prevy;
 
         switch (gesture.type) {
-        case kTap:
+            case kTap:
             if (gesture.numberOfTouches == 1) {
-                mouse_simulate_input(0, 0, MOUSE_STATE_LEFT_BUTTON_DOWN);
+                // Save current cursor position
+                int current_x, current_y;
+                mouse_get_position(&current_x, &current_y);
+
+                // Simulate moving the cursor (move) to a new position
+                mouse_simulate_input(gesture.x - current_x, gesture.y - current_y, MOUSE_STATE_LEFT_BUTTON_DOWN);
             } else if (gesture.numberOfTouches == 2) {
                 mouse_simulate_input(0, 0, MOUSE_STATE_RIGHT_BUTTON_DOWN);
+            } else if (gesture.numberOfTouches == 3) {
+                mouse_simulate_input(0, 0, MOUSE_STATE_LEFT_BUTTON_DOWN);
             }
             break;
         case kLongPress:
@@ -497,7 +505,6 @@ void mouse_info()
         y = 0;
     }
 
-    // Adjust for mouse senstivity.
     x = (int)(x * mouse_sensitivity);
     y = (int)(y * mouse_sensitivity);
 
@@ -515,8 +522,6 @@ void mouse_info()
 
     mouse_simulate_input(x, y, buttons);
 
-    // TODO: Move to `_mouse_simulate_input`.
-    // TODO: Record wheel event in VCR.
     gMouseWheelX = mouseData.wheelX;
     gMouseWheelY = mouseData.wheelY;
 
@@ -525,6 +530,7 @@ void mouse_info()
         raw_buttons |= MOUSE_EVENT_WHEEL;
     }
 }
+
 
 // 0x4B4ECC
 void mouse_simulate_input(int delta_x, int delta_y, int buttons)
@@ -649,6 +655,22 @@ bool mouse_in(int left, int top, int right, int bottom)
 }
 
 // 0x4B51C0
+// Expanding cursor hot Size for touch devices
+bool mouse_click_in(int left, int top, int right, int bottom)
+{
+    int expand = 10; // Extend active area by 10 pixels (set as needed)
+
+    if (!have_mouse) {
+        return false;
+    }
+
+    return (mouse_hoty + mouse_y >= top - expand) &&
+           (mouse_hotx + mouse_x <= right + expand) &&
+           (mouse_hotx + mouse_x >= left - expand) &&
+           (mouse_hoty + mouse_y <= bottom + expand);
+}
+
+/*
 bool mouse_click_in(int left, int top, int right, int bottom)
 {
     if (!have_mouse) {
@@ -660,6 +682,7 @@ bool mouse_click_in(int left, int top, int right, int bottom)
         && mouse_hotx + mouse_x >= left
         && mouse_hoty + mouse_y <= bottom;
 }
+ */
 
 // 0x4B522C
 void mouse_get_rect(Rect* rect)


### PR DESCRIPTION
Added better touch controls for touch devices (iOS, Android).

One finger tap moves mouse cursor to the tapped position and does left mouse click. (new!)
One finger drag moves mouse cursor around. The finger doesn't have to be at the cursor position, but anywhere on the screen. This is useful for accurate selection of dialogue options, and precise aiming during combat.
Tap two fingers for right mouse click (switches mouse cursor mode).
Move two fingers to scroll current view (map view, worldmap view, inventory scrollers).
Tap with three fingers to simulate a left mouse button click at the cursor's current location without moving it. This is ideal for accurately selecting dialogue options or executing precise attacks during combat.

Also edited Readme.md with this explanation.

Fixes #180 