### PR TITLE
Fix incorrect text displaying with Russian 1C localization

### DIFF
--- a/src/game/fontmgr.cc
+++ b/src/game/fontmgr.cc
@@ -245,7 +245,7 @@ int FMtext_char_width(char c)
     if (c == ' ') {
         width = gCurrentFont->wordSpacing;
     } else {
-        width = gCurrentFont->glyphs[c].width;
+        width = gCurrentFont->glyphs[(unsigned char)c].width;
     }
 
     return width;


### PR DESCRIPTION
### Issue
With 1C Russian localization, texts with letter 'ю'(0xFE) are displayed incorrectly or not displayed at all.
<img width="289" height="180" alt="bug" src="https://github.com/user-attachments/assets/eb0c7777-8d28-4534-93db-3ed5b76fb909" />
This issue has already been reported #157 
### Solution
Argument of function FMtext_char_width(char c) is (signed) char, so line:
`
width = gCurrentFont->glyphs[c].width;
`
may lead to accessing the wrong memory cell.
Casting the 'c' variable to a unsigned char type(, like in FMtext_width,) solves this problem.

<img width="288" height="180" alt="fix" src="https://github.com/user-attachments/assets/18fdd791-9007-4121-bb4c-100e8ff8931b" />