### PR TITLE
fix(combatai): undefined behavior fix causing crashes in release mode…

### DIFF
--- a/src/game/combatai.cc
+++ b/src/game/combatai.cc
@@ -533,7 +533,7 @@ static int ai_find_attackers(Object* critter, Object** a2, Object** a3, Object**
         *a3 = NULL;
     }
 
-    if (*a4 != NULL) {
+    if (a4 != NULL) {
         *a4 = NULL;
     }
 


### PR DESCRIPTION
… clang

a4 was being dereferenced as an uninitialized stack value, which causes clang to optimize out a null check in `ai_danger_source` causing runtime crashes